### PR TITLE
Add biocViews keyword

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,4 @@ BugReports: https://github.com/sunduanchen/Scissor/issues
 URL: https://github.com/sunduanchen/Scissor
 RoxygenNote: 7.1.1
 Encoding: UTF-8
+biocViews:


### PR DESCRIPTION
This enable automatic download of bioconductor dependencies through `install_github`

Likely fixes #4. 